### PR TITLE
Starting with Elasticsearch 5.3 http header Content-Type is required

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,8 @@ export async function executeQuery(context: vscode.ExtensionContext, resultsProv
         method: em.Method.Text,
         body: em.Body.Text,
         headers: {
-            'Accept': 'application/json'
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
         }
     }, (error, response, body) => {
 


### PR DESCRIPTION
See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests for more information