### PR TITLE
Fix a bug when workspace not open any folder, unable to query. And fix non-json result issue.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,8 +195,12 @@ export async function executeQuery(context: vscode.ExtensionContext, resultsProv
 
             let results = body;
             if (asDocument) {
-                results = JSON.stringify(JSON.parse(results), null, 4)
-                showResult(results, vscode.window.activeTextEditor.viewColumn + 1)
+                try {
+                    results = JSON.stringify(JSON.parse(results), null, 4);
+                } catch (error) {
+                    results = body;
+                }
+                showResult(results, vscode.window.activeTextEditor.viewColumn + 1);
             }
             else {
                 resultsProvider.update(context, host, results, endTime - startTime, response.statusCode, response.statusMessage);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as request from 'request';
 import url = require('url');
 import path = require('path');
 import * as fs from 'fs';
+import * as os from 'os';
 
 
 import { ElasticCodeLensProvider } from './ElasticCodeLensProvider'
@@ -207,7 +208,10 @@ export async function executeQuery(context: vscode.ExtensionContext, resultsProv
 
 
 function showResult(result: string, column?: vscode.ViewColumn): Thenable<void> {
-    let uri = vscode.Uri.file(path.join(vscode.workspace.rootPath, 'result.json'));
+    const tempResultFilePath = path.join(os.homedir(), '.vscode-elastic');
+    const resultFilePath = vscode.workspace.rootPath || tempResultFilePath;
+
+    let uri = vscode.Uri.file(path.join(resultFilePath, 'result.json'));
     if (!fs.existsSync(uri.fsPath)) {
         uri = uri.with({ scheme: 'untitled' });
     }


### PR DESCRIPTION
When workspace do not open any folder, the vscode.workspace.rootPath will be null, so path.join will throw a exception. fix this by temp saving the result at home dir.