### PR TITLE
fix(compile): Upgrade TypeScript to v4.1.3 in order to fix compile command

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
 		"jsesc": "^2.5.1",
 		"mocha": "^3.5.0",
 		"require-dir": "^0.3.2",
-		"typescript": "^2.5.2",
+		"typescript": "^4.1.3",
 		"vscode": "^1.1.5"
 	}
 }


### PR DESCRIPTION
I've faced with issue that did't allow to compile typescript files in order to publish extension to [Open VSX](https://open-vsx.org/) registry due to issue during compilation.
I've upgraded TypeScript to v4.1.3 to fix this issue.

![image](https://user-images.githubusercontent.com/1110697/102685878-517a7800-41ec-11eb-9f4d-90e986a4e553.png)
